### PR TITLE
fix: Using Angular 9 Ivy -> could not serialize promise result. #1

### DIFF
--- a/worker/src/lib/worker-controller.ts
+++ b/worker/src/lib/worker-controller.ts
@@ -158,15 +158,8 @@ export class WorkerController<T> {
     async handleCallable(request: WorkerRequestEvent<WorkerEvents.Callable>) {
         let response: WorkerResponseEvent<any>;
         try {
-            const metaData = WorkerUtils.getAnnotation<CallableMetaData[]>(this.workerClass, WorkerAnnotations.Callables);
             request.body.arguments = this.applyShallowTransferToCallableArgs(request, request.body.arguments);
-            let result: any;
-
-            if (metaData.filter(x => x.name === request.propertyName)[0].returnType === Promise) {
-                result = await this.worker[request.propertyName](...request.body.arguments);
-            } else {
-                result = this.worker[request.propertyName](...request.body.arguments);
-            }
+            const result = await this.worker[request.propertyName](...request.body.arguments);
 
             response = this.response(WorkerEvents.Callable, request, result);
         } catch (e) {


### PR DESCRIPTION
We are awaiting all the responses from the callable methods, since awaiting not-promise stuff will just return them. This way we do not need rely on metadata, which previously returned undefined for `returnType` property.